### PR TITLE
correct vamp-mesosphere version

### DIFF
--- a/docker-compositions/vamp-marathon-mesos/docker-compose.yml
+++ b/docker-compositions/vamp-marathon-mesos/docker-compose.yml
@@ -70,7 +70,7 @@ marathon:
 # Vamp
 #
 vamp:
-  image: magneticio/vamp-mesosphere:latest
+  image: magneticio/vamp-mesosphere:0.7.7
   ports:
     - "8081:8080"
     - "8083:8083"


### PR DESCRIPTION
Hi @tnolet,

there is no latest version (https://registry.hub.docker.com/u/magneticio/vamp-mesosphere/tags/manage/). Compose fails because of this with the following error:

berndzuther@cc-4 ~/development/vamp-docker/docker-compositions/vamp-marathon-mesos (master)$ docker-compose up
Recreating vampmarathonmesos_zk_1...
Recreating vampmarathonmesos_slave1_1...
Recreating vampmarathonmesos_master_1...
Recreating vampmarathonmesos_slave2_1...
Recreating vampmarathonmesos_marathon_1...
Creating vampmarathonmesos_vamp_1...
Pulling image magneticio/vamp-mesosphere:latest...
Pulling repository magneticio/vamp-mesosphere
Traceback (most recent call last):
  File "/usr/local/Cellar/fig/1.2.0/libexec/bin/docker-compose", line 9, in <module>
    load_entry_point('docker-compose==1.2.0', 'console_scripts', 'docker-compose')()
  File "/usr/local/Cellar/fig/1.2.0/libexec/lib/python2.7/site-packages/compose/cli/main.py", line 31, in main
    command.sys_dispatch()
  File "/usr/local/Cellar/fig/1.2.0/libexec/lib/python2.7/site-packages/compose/cli/docopt_command.py", line 21, in sys_dispatch
    self.dispatch(sys.argv[1:], None)
  File "/usr/local/Cellar/fig/1.2.0/libexec/lib/python2.7/site-packages/compose/cli/command.py", line 27, in dispatch
    super(Command, self).dispatch(_args, *_kwargs)
  File "/usr/local/Cellar/fig/1.2.0/libexec/lib/python2.7/site-packages/compose/cli/docopt_command.py", line 24, in dispatch
    self.perform_command(_self.parse(argv, global_options))
  File "/usr/local/Cellar/fig/1.2.0/libexec/lib/python2.7/site-packages/compose/cli/command.py", line 59, in perform_command
    handler(project, command_options)
  File "/usr/local/Cellar/fig/1.2.0/libexec/lib/python2.7/site-packages/compose/cli/main.py", line 464, in up
    do_build=not options['--no-build'],
  File "/usr/local/Cellar/fig/1.2.0/libexec/lib/python2.7/site-packages/compose/project.py", line 208, in up
    do_build=do_build):
  File "/usr/local/Cellar/fig/1.2.0/libexec/lib/python2.7/site-packages/compose/service.py", line 214, in recreate_containers
    *_override_options)
  File "/usr/local/Cellar/fig/1.2.0/libexec/lib/python2.7/site-packages/compose/service.py", line 199, in create_container
    stream_output(output, sys.stdout)
  File "/usr/local/Cellar/fig/1.2.0/libexec/lib/python2.7/site-packages/compose/progress_stream.py", line 37, in stream_output
    print_output_event(event, stream, is_terminal)
  File "/usr/local/Cellar/fig/1.2.0/libexec/lib/python2.7/site-packages/compose/progress_stream.py", line 50, in print_output_event
    raise StreamOutputError(event['errorDetail']['message'])
compose.progress_stream.StreamOutputError: Tag latest not found in repository magneticio/vamp-mesosphere
