### PR TITLE
Added quickstart and uninstall scripts for kubernetes

### DIFF
--- a/vamp-kubernetes/vamp_kube_quickstart.sh
+++ b/vamp-kubernetes/vamp_kube_quickstart.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+NAMESPACE=$1
+
+# assign namespace default if not given
+: ${NAMESPACE:=default}
+
+ETCD_YAML=https://raw.githubusercontent.com/magneticio/vamp-docker/master/vamp-kubernetes/etcd.yml
+VGA_YAML=https://raw.githubusercontent.com/magneticio/vamp.io/master/static/res/vga.yml
+ES_IMG=magneticio/elastic:2.2
+VAMP_IMG=magneticio/vamp:0.9.1-kubernetes
+
+error() {
+    echo "[ERROR] $1"
+    echo
+    exit 1
+}
+
+step() {
+    echo "[STEP] $1"
+}
+
+ok() {
+    echo "[OK] $1"
+}
+
+verify_kubectl() {
+    step "Verifying kubectl install"
+    export KUBECTL=$(which kubectl)
+
+    if [ ! $? = 0 ]; then
+        error "Kubectl not found, cannot continue"
+    fi
+
+    # verify the namespace
+    ${KUBECTL} get ns ${NAMESPACE} &> /dev/null
+    if [ ! $? = 0 ]; then
+        step "Creating namespace: ${NAMESPACE}"
+        kubectl create ns ${NAMESPACE} 1> /dev/null
+
+        if [ ! $? = 0 ] ; then
+            error "Cannot create namespace ${NAMESPACE}!"
+        fi
+    fi
+
+    ok "Using namespace: ${NAMESPACE}"
+}
+
+install_yaml() {
+    step "Creating ${1} in namespace ${NAMESPACE}"
+    CREATION=$(${KUBECTL} --namespace ${NAMESPACE} create -f ${1} 2>&1)
+
+    if [[ ${CREATION} == *"already exists"* ]] ; then
+        error "Cannot apply ${1}, already present in ${NAMESPACE}"
+    fi
+
+    ok "$2 created successfully"
+}
+
+expose() {
+    step "Exposing port $3/$2($4) for deployment $1 with type $5"
+    EXPOSE_SVC=$(${KUBECTL} expose deployment $1 --protocol=$2 --port=$3 --name=$4 --type="$5" --namespace=${NAMESPACE} 2>&1)
+
+    if [ ! $? = 0 ]; then
+        error "Failed to expose port $3/$2 ($4). Deployment: $1"
+    fi
+}
+
+run() {
+    step "Running $1 ($2)"
+    RUN_CMD=$(${KUBECTL} run $1 --image=$2 --namespace=${NAMESPACE} 2>&1)
+
+    if [ ! $? = 0 ]; then
+        error "Failed to run $1. Image: $2"
+    fi
+
+    ok "$1 is running"
+}
+
+install() {
+    install_yaml ${ETCD_YAML}
+    install_yaml ${VGA_YAML}
+
+    # run and expose elasticsearch
+    run elastic ${ES_IMG}
+    expose "elastic" "TCP" 9200 "elasticsearch" "ClusterIP"
+    expose "elastic" "UDP" 10001 "logstash" "ClusterIP"
+    expose "elastic" "TCP" 5601 "kibana" "ClusterIP"
+
+    # run and expose vamp
+    run "vamp" ${VAMP_IMG}
+    expose "vamp" "TCP" 8080 "vamp" "LoadBalancer"
+
+}
+step "Vamp Kubernetes Quickstart running"
+echo
+
+# run the pre install
+verify_kubectl
+
+# run the installation on kubernetes
+install
+
+step "Polling kubernetes for external ip of Vamp..."
+# poll for the external ip address
+external_ip=""
+while [ -z $external_ip ]; do
+    sleep 5
+    external_ip=$(${KUBECTL} --namespace ${NAMESPACE} get svc vamp --template="{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}")
+
+    if [ ! $? = 0 ]; then
+        error "Failed to retrieve external ip address for vamp"
+    fi
+
+    step "Still polling for Vamp ip..."
+done
+
+ok "Quickstart finished, Vamp is running on http://$external_ip:8080"
+exit 0

--- a/vamp-kubernetes/vamp_kube_uninstall.sh
+++ b/vamp-kubernetes/vamp_kube_uninstall.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+NAMESPACE=$1
+
+# assign namespace default if not given
+: ${NAMESPACE:=default}
+
+ETCD_YAML=https://raw.githubusercontent.com/magneticio/vamp-docker/master/vamp-kubernetes/etcd.yml
+VGA_YAML=https://raw.githubusercontent.com/magneticio/vamp.io/master/static/res/vga.yml
+
+error() {
+    echo "[ERROR] $1"
+    echo
+    exit 1
+}
+
+ok() {
+    echo "[OK] $1"
+}
+
+step() {
+    echo "[STEP] $1"
+}
+
+verify_kubectl() {
+    step "Verifying kubectl install"
+    export KUBECTL=$(which kubectl)
+
+    if [ ! $? = 0 ]; then
+        error "Kubectl not found, cannot continue"
+    fi
+
+    ok "Using namespace: ${NAMESPACE}"
+
+    # verify the namespace
+    ${KUBECTL} get ns ${NAMESPACE} &> /dev/null
+    if [ ! $? = 0 ]; then
+        error "Namespace ${NAMESPACE} was not found!"
+    fi
+}
+
+delete() {
+    step "Running delete command: $1"
+    DELETE_CMD=$(${KUBECTL} --namespace ${NAMESPACE} delete $1)
+
+    if [ ! $? = 0 ]; then
+        error "Delete command ${1} has failed, skipping"
+    fi
+}
+
+verify_kubectl
+
+step "Uninstalling vamp from namespace ${NAMESPACE}"
+
+delete "-f ${ETCD_YAML}"
+delete "-f ${VGA_YAML}"
+
+delete "pods,services,deployments -l run=vamp"
+delete "pods,services,deployments -l run=elastic"
+# delete "deployments -l run=vamp"
+delete "services -l vamp=deamon"


### PR DESCRIPTION
Created two scripts: 

vamp_kube_quickstart.sh and vamp_kube_uninstall.sh to automate the installation steps provided on the vamp website to make things a bit easier for developers to get started with vamp on kubernetes.

Will update the website docs as well if this PR gets accepted.