### PR TITLE
Support for Makefile.local when building images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+
+Makefile.local

--- a/pack.sh
+++ b/pack.sh
@@ -43,6 +43,10 @@ pack() {
 
   fi
 
+  if [[ -f ${root}/Makefile.local ]]; then
+    cp ${root}/Makefile.local ${workspace}/${project}/
+  fi
+
   make pack
 }
 


### PR DESCRIPTION
While building the Vamp docker images I would like to change the builder server image which is already supported by the makefiles in the vamp-* repositories.

*Note: [magneticio/buildserver - Use OpenJDK development version instead of runtime only](https://github.com/magneticio/buildserver/pull/11)*
