### PR TITLE
fix clique-etcd and clique-zookeeper

### DIFF
--- a/clique-etcd/Dockerfile
+++ b/clique-etcd/Dockerfile
@@ -2,7 +2,7 @@ FROM magneticio/vamp-clique-base:VAMP_VERSION
 
 ENV ETCD_VERSION 2.3.7
 
-ADD https://github.com/coreos/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-amd64.tar.gz /
+RUN wget https://github.com/coreos/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-amd64.tar.gz
 
 RUN set -ex && \
     tar xzvf etcd-v$ETCD_VERSION-linux-amd64.tar.gz && \

--- a/clique-zookeeper/make.sh
+++ b/clique-zookeeper/make.sh
@@ -13,18 +13,25 @@ mkdir -p ${target} && cd ${target}
 
 echo "${green}building: ${yellow}zk-web${reset}"
 
+build_server="magneticio/buildserver"
+docker pull $build_server
+
 if [[ -d ${target}/zk-web ]] ; then
-  rm -rf ${target}/zk-web
+
+  docker run \
+    --interactive \
+    --rm \
+    --volume ${target}:/srv/src \
+    --workdir=/srv/src \
+    $build_server \
+      rm -rf /srv/src/zk-web
 fi
 
 git clone --depth=1 https://github.com/qiuxiafei/zk-web.git
 cd ${target}/zk-web
 
-build_server="magneticio/buildserver"
-docker pull $build_server
 docker run \
   --interactive \
-  --tty \
   --rm \
   --volume ${target}/zk-web:/srv/src \
   --workdir=/srv/src \


### PR DESCRIPTION
- change etcd download method
- remove tty flag (required for Jenkins)
- use rm inside the container in order to handle permission issue