### PR TITLE
Updated dockerfile to Alpine 3.11 and Java 8u242

### DIFF
--- a/alpine-jdk/Dockerfile
+++ b/alpine-jdk/Dockerfile
@@ -2,7 +2,7 @@
 # From: https://github.com/docker-library/openjdk/blob/9a0822673dffd3e5ba66f18a8547aa60faed6d08/8-jre/alpine/Dockerfile
 
 # this is updated for java 9 backported features
-FROM alpine:3.6
+FROM alpine:3.11
 
 # A few problems with compiling Java from source:
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
@@ -24,8 +24,8 @@ RUN { \
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk/jre
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
 
-ENV JAVA_VERSION 8u131
-ENV JAVA_ALPINE_VERSION 8.131.11-r2
+ENV JAVA_VERSION 8u242
+ENV JAVA_ALPINE_VERSION 8.242.08-r0
 
 RUN set -x \
 	&& apk add --no-cache \


### PR DESCRIPTION
Currently used alpine version 3.6 is end of life May 2019 and Java is outdated with known security issues,